### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/philipcristiano/HelloIDC/compare/v0.1.0...v0.1.1) - 2023-12-05
+
+### Other
+- Use service_conventions for tracing setup

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,7 +861,7 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hello_idc"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello_idc"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Hello World with OIDC auth"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `hello_idc`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/philipcristiano/HelloIDC/compare/v0.1.0...v0.1.1) - 2023-12-05

### Other
- Use service_conventions for tracing setup
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).