### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/philipcristiano/hello_idc/compare/v0.1.1...v0.1.2) - 2024-01-29
+
+### Other
+- *(deps)* bump the patch-dependencies group with 2 updates
+- *(deps)* bump the patch-dependencies group with 1 update
+- Use explicit Action token
+- Use packaged maud
+- *(deps)* bump the patch-dependencies group with 3 updates
+- *(deps)* bump the patch-dependencies group with 4 updates
+- axum 0.7 / maud >0.25 compat
+- *(deps)* bump the minor-dependencies group with 9 updates
+- *(deps)* bump rust from 1.74-bookworm to 1.75-bookworm
+- *(deps)* bump agenthunt/conventional-commit-checker-action
+
 ## [0.1.1](https://github.com/philipcristiano/HelloIDC/compare/v0.1.0...v0.1.1) - 2023-12-05
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,7 +931,7 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hello_idc"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "axum 0.7.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello_idc"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Hello World with OIDC auth"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `hello_idc`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/philipcristiano/hello_idc/compare/v0.1.1...v0.1.2) - 2024-01-29

### Other
- *(deps)* bump the patch-dependencies group with 2 updates
- *(deps)* bump the patch-dependencies group with 1 update
- Use explicit Action token
- Use packaged maud
- *(deps)* bump the patch-dependencies group with 3 updates
- *(deps)* bump the patch-dependencies group with 4 updates
- axum 0.7 / maud >0.25 compat
- *(deps)* bump the minor-dependencies group with 9 updates
- *(deps)* bump rust from 1.74-bookworm to 1.75-bookworm
- *(deps)* bump agenthunt/conventional-commit-checker-action
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).