### PR TITLE
chore: Remove outdated dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ axum = "0.7.5"
 clap = { version = "4.5.4", features = ["derive", "env"]}
 maud = { version = "0.26.0", features = ["axum"] }
 once_cell = "1.19.0"
-openidconnect = "3.5.0"
 serde = { version = "1.0.200", features = ["derive"] }
 serde_json = "1.0.116"
 service_conventions = { version = "0.0.24", features = ["tracing", "oidc"]}


### PR DESCRIPTION
no longer directly using openidconnect, it's provided by rust_service_conventions